### PR TITLE
Tests, fixes and test fixes

### DIFF
--- a/DsmSuite.Analyzer.DotNet.Lib/BinaryFile.cs
+++ b/DsmSuite.Analyzer.DotNet.Lib/BinaryFile.cs
@@ -13,14 +13,15 @@ namespace DsmSuite.Analyzer.DotNet.Lib
     public class BinaryFile
     {
         private readonly IProgress<ProgressInfo> _progress;
-        private readonly IList<TypeDefinition> _typeList = new List<TypeDefinition>();
-        private readonly IList<String> _includedAssemblyStrings = new List<String>();
+        private readonly List<TypeDefinition> _typeList = new List<TypeDefinition>();
+        private readonly List<String> _includedAssemblyStrings = new List<String>();
 
         public BinaryFile(string filename, IProgress<ProgressInfo> progress, List<String> includedAssemblyStrings)
         {
             FileInfo = new FileInfo(filename);
             _progress = progress;
-            _includedAssemblyStrings = includedAssemblyStrings;
+            if (includedAssemblyStrings != null)
+                _includedAssemblyStrings.AddRange(includedAssemblyStrings);
         }
 
         public List<DotNetType> Types { get; } = new List<DotNetType>();

--- a/DsmSuite.Analyzer.DotNet.Test/Analysis/AnalyzerTest.cs
+++ b/DsmSuite.Analyzer.DotNet.Test/Analysis/AnalyzerTest.cs
@@ -11,13 +11,8 @@ namespace DsmSuite.Analyzer.DotNet.Test.Analysis
     [TestClass]
     public class AnalyzerTest
     {
-        [TestMethod]
-        public void TestAnalyze()
+        private void TestAnalyze(AnalyzerSettings analyzerSettings)
         {
-            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
-            analyzerSettings.Input.AssemblyDirectory = TestData.RootDirectory;
-            analyzerSettings.Transformation.IgnoredNames = new List<string>();
-
             IDsiModel model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
             DotNet.Analysis.Analyzer analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
             analyzer.Analyze();
@@ -81,30 +76,30 @@ namespace DsmSuite.Analyzer.DotNet.Test.Analysis
             IDsiElement elementGenericParameterType = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericParameterType`1");
             Assert.IsNotNull(elementGenericParameterType);
 
-            IDsiElement elementGenericParameterTypeParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericParameterTypeParameter"); 
+            IDsiElement elementGenericParameterTypeParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericParameterTypeParameter");
             Assert.IsNotNull(elementGenericParameterTypeParameter);
 
             // Return types
-            IDsiElement elementReturnType = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.ReturnType"); 
+            IDsiElement elementReturnType = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.ReturnType");
             Assert.IsNotNull(elementReturnType);
 
-            IDsiElement elementReturnEnum = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.ReturnEnum"); 
+            IDsiElement elementReturnEnum = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.ReturnEnum");
             Assert.IsNotNull(elementReturnEnum);
 
-            IDsiElement elementGenericReturnType = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericReturnType`1"); 
+            IDsiElement elementGenericReturnType = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericReturnType`1");
             Assert.IsNotNull(elementGenericReturnType);
 
-            IDsiElement elementGenericReturnTypeParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericReturnTypeParameter"); 
+            IDsiElement elementGenericReturnTypeParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.GenericReturnTypeParameter");
             Assert.IsNotNull(elementGenericReturnTypeParameter);
 
             IDsiElement elementDelegateGenericParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.DelegateGenericParameter");
             Assert.IsNotNull(elementDelegateGenericParameter);
 
-            IDsiElement elementEventsArgsGenericParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.EventsArgsGenericParameter"); 
+            IDsiElement elementEventsArgsGenericParameter = model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.EventsArgsGenericParameter");
             Assert.IsNotNull(elementEventsArgsGenericParameter);
 
             // Main relations
-            Assert.IsTrue(model.DoesRelationExist(elementMainClient.Id, elementMainType.Id)); 
+            Assert.IsTrue(model.DoesRelationExist(elementMainClient.Id, elementMainType.Id));
             Assert.IsTrue(model.DoesRelationExist(elementMainClient.Id, elementEventsArgsGenericParameter.Id));
 
             Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementNestedType.Id));
@@ -116,15 +111,15 @@ namespace DsmSuite.Analyzer.DotNet.Test.Analysis
             Assert.IsTrue(model.DoesRelationExist(elementMainTypeAnonymous.Id, elementDelegateGenericParameter.Id));
             Assert.IsTrue(model.DoesRelationExist(elementMainTypeAnonymous.Id, elementDelegateGenericParameter.Id));
 
-            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementInterfaceA.Id)); 
-            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementBaseType.Id)); 
+            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementInterfaceA.Id));
+            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementBaseType.Id));
 
             Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementEventsArgsGenericParameter.Id));
             Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementDelegateGenericParameter.Id));
 
             // Field relations
-            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementFieldType.Id)); 
-            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementGenericFieldType.Id)); 
+            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementFieldType.Id));
+            Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementGenericFieldType.Id));
 
             // Property relations
             Assert.IsTrue(model.DoesRelationExist(elementMainType.Id, elementPropertyType.Id));
@@ -156,6 +151,110 @@ namespace DsmSuite.Analyzer.DotNet.Test.Analysis
             Assert.IsTrue(model.DoesRelationExist(elementInterfaceA.Id, elementReturnEnum.Id));
             Assert.IsTrue(model.DoesRelationExist(elementInterfaceA.Id, elementGenericReturnType.Id));
             Assert.IsTrue(model.DoesRelationExist(elementInterfaceA.Id, elementGenericReturnTypeParameter.Id));
+        }
+
+        [TestMethod]
+        public void TestAnalyzeDirectory()
+        {
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectory = TestData.RootDirectory;
+            analyzerSettings.Transformation.IgnoredNames = new List<string>();
+
+            TestAnalyze(analyzerSettings);
+        }
+
+        [TestMethod]
+        public void TestAnalyzeDirectories()
+        {
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectories = new List<string> { TestData.RootDirectory };
+            analyzerSettings.Transformation.IgnoredNames = new List<string>();
+
+            TestAnalyze(analyzerSettings);
+        }
+
+        [TestMethod]
+        public void TestIncludeAssemblyNames()
+        {
+            IDsiModel model;
+            DotNet.Analysis.Analyzer analyzer;
+
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectories = new List<string> { TestData.RootDirectory };
+            analyzerSettings.Transformation.IgnoredNames = new List<string>();
+
+            analyzerSettings.Input.IncludeAssemblyNames = new List<string> { @".*" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+
+            analyzerSettings.Input.IncludeAssemblyNames = new List<string> { @"Model", @"Dot[Nn]et\.Test\.(Data)?" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+
+            analyzerSettings.Input.IncludeAssemblyNames = new List<string> { @"Model" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+        }
+
+        [TestMethod]
+        public void TestIncludedNames()
+        {
+            IDsiModel model;
+            DotNet.Analysis.Analyzer analyzer;
+
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectories = new List<string> { TestData.RootDirectory };
+            analyzerSettings.Transformation.IgnoredNames = new List<string>();
+
+            analyzerSettings.Transformation.IncludedNames = new List<string> { @"Model", @"Dot[Nn]et\.Test\.(Data)?.Main" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+            Assert.IsNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.BaseType"));
+        }
+
+        [TestMethod]
+        public void TestIgnoredNames()
+        {
+            IDsiModel model;
+            DotNet.Analysis.Analyzer analyzer;
+
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectories = new List<string> { TestData.RootDirectory };
+            analyzerSettings.Transformation.IncludedNames = new List<string>();
+
+            analyzerSettings.Transformation.IgnoredNames = new List<string> { @"Model", @"/" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainType"));
+            Assert.IsNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainType/NestedType"));
+        }
+        [TestMethod]
+        public void TestIncludedIgnoredNames()
+        {
+            IDsiModel model;
+            DotNet.Analysis.Analyzer analyzer;
+
+            AnalyzerSettings analyzerSettings = AnalyzerSettings.CreateDefault();
+            analyzerSettings.Input.AssemblyDirectories = new List<string> { TestData.RootDirectory };
+            analyzerSettings.Transformation.IncludedNames = new List<string> { @"Main" };
+
+            analyzerSettings.Transformation.IgnoredNames = new List<string> { @"MainType$" };
+            model = new DsiModel("Test", analyzerSettings.Transformation.IgnoredNames, Assembly.GetExecutingAssembly());
+            analyzer = new DotNet.Analysis.Analyzer(model, analyzerSettings, null);
+            analyzer.Analyze();
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainClient"));
+            Assert.IsNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainType"));
+            Assert.IsNotNull(model.FindElementByName("DsmSuite.Analyzer.DotNet.Test.Data.MainType/NestedType"));
         }
     }
 }

--- a/DsmSuite.Analyzer.DotNet/Analysis/Analyzer.cs
+++ b/DsmSuite.Analyzer.DotNet/Analysis/Analyzer.cs
@@ -37,8 +37,7 @@ namespace DsmSuite.Analyzer.DotNet.Analysis
         {
             //For every configured assembly directory lookup the files in the
             //directory and process the content of the files
-            IList<string> assemblyFolders = _analyzerSettings.Input.AssemblyDirectories;
-            foreach (string assemblyFolder in assemblyFolders)
+            foreach (string assemblyFolder in _analyzerSettings.AssemblyDirectories())
             {
                 Logger.LogUserMessage($"Assembly folder: {assemblyFolder}");
                 foreach (string assemblyFilename in Directory.EnumerateFiles(assemblyFolder))
@@ -82,12 +81,12 @@ namespace DsmSuite.Analyzer.DotNet.Analysis
 
         private bool Accept(string name)
         {
-            /*  Check wether the name meets the regex descriptions that have been configured.
+            /*  Check whether the name meets the regex descriptions that have been configured.
              *  If no regex descriptions have been configured then the file is accepted.
              */
             bool accept = false;
 
-            if (_analyzerSettings.Input.IncludeAssemblyNames.Count > 0)
+            if (_analyzerSettings.Input.IncludeAssemblyNames?.Count > 0)
             {
                 string fileNameWithoutExtension = "";
                 try

--- a/DsmSuite.Analyzer.DotNet/Program.cs
+++ b/DsmSuite.Analyzer.DotNet/Program.cs
@@ -19,8 +19,7 @@ namespace DsmSuite.Analyzer.DotNet
         protected override bool CheckPrecondition()
         {
             bool result = true;
-            IList<string> assemblyFolders = _analyzerSettings.Input.AssemblyDirectories;
-            foreach (string assemblyFolder in assemblyFolders)
+            foreach (string assemblyFolder in _analyzerSettings.AssemblyDirectories())
             {
                 if (!Directory.Exists(assemblyFolder))
                 {

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementChangeNameActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementChangeNameActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using System.Collections.Generic;
 using DsmSuite.DsmViewer.Application.Actions.Element;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -59,8 +60,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementChangeNameAction action = new ElementChangeNameAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementChangeNameAction action = Activator.CreateInstance(typeof(ElementChangeNameAction), args) as ElementChangeNameAction;
 
             Assert.AreEqual(3, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementChangeTypeActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementChangeTypeActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using System.Collections.Generic;
 using DsmSuite.DsmViewer.Application.Actions.Element;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -59,8 +60,9 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementChangeTypeAction action = new ElementChangeTypeAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementChangeTypeAction action =
+                    Activator.CreateInstance(typeof(ElementChangeTypeAction), args) as ElementChangeTypeAction;
 
             Assert.AreEqual(3, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementCreateActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementCreateActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using System.Collections.Generic;
 using DsmSuite.DsmViewer.Application.Actions.Element;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -58,8 +59,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void WhenUndoActionThenElementIsRemovedFromDataModel()
         {
-            object[] args = { _model.Object, _data };
-            ElementCreateAction action = new ElementCreateAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementCreateAction action = Activator.CreateInstance(typeof(ElementCreateAction), args) as ElementCreateAction;
             action.Undo();
             Assert.IsTrue(action.IsValid());
 
@@ -69,8 +70,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementCreateAction action = new ElementCreateAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementCreateAction action = Activator.CreateInstance(typeof(ElementCreateAction), args) as ElementCreateAction;
 
             Assert.AreEqual(5, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementDeleteActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementDeleteActionTest.cs
@@ -3,6 +3,7 @@ using Moq;
 using DsmSuite.DsmViewer.Model.Interfaces;
 using DsmSuite.DsmViewer.Application.Actions.Element;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -53,8 +54,9 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementDeleteAction action = new ElementDeleteAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementDeleteAction action =
+                    Activator.CreateInstance(typeof(ElementDeleteAction), args) as ElementDeleteAction;
 
             Assert.AreEqual(1, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementMoveDownActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementMoveDownActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using DsmSuite.DsmViewer.Application.Actions.Element;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -59,8 +60,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementMoveDownAction action = new ElementMoveDownAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementMoveDownAction action = Activator.CreateInstance(typeof(ElementMoveDownAction), args) as ElementMoveDownAction;
 
             Assert.AreEqual(1, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementMoveUpActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementMoveUpActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using DsmSuite.DsmViewer.Application.Actions.Element;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -59,8 +60,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementMoveUpAction action = new ElementMoveUpAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementMoveUpAction action = Activator.CreateInstance(typeof(ElementMoveUpAction), args) as ElementMoveUpAction;
 
             Assert.AreEqual(1, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementSortActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Element/ElementSortActionTest.cs
@@ -5,6 +5,7 @@ using DsmSuite.DsmViewer.Application.Actions.Element;
 using System.Collections.Generic;
 using DsmSuite.DsmViewer.Application.Sorting;
 using DsmSuite.DsmViewer.Application.Test.Stubs;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
 {
@@ -53,8 +54,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void WhenUndoActionThenElementsChildrenAreSortIsReverted()
         {
-            object[] args = { _model.Object, _data };
-            ElementSortAction action = new ElementSortAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementSortAction action = Activator.CreateInstance(typeof(ElementSortAction), args) as ElementSortAction;
             action.Undo();
             Assert.IsTrue(action.IsValid());
 
@@ -64,8 +65,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Element
         [TestMethod]
         public void GivenLoadedActionWhenGettingDataThenActionAttributesMatch()
         {
-            object[] args = { _model.Object, _data };
-            ElementSortAction action = new ElementSortAction(args);
+            object[] args = { _model.Object, null, _data };
+            ElementSortAction action = Activator.CreateInstance(typeof(ElementSortAction), args) as ElementSortAction;
 
             Assert.AreEqual(3, action.Data.Count);
             Assert.AreEqual(ElementId.ToString(), _data["element"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationChangeTypeActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationChangeTypeActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using DsmSuite.DsmViewer.Application.Actions.Relation;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
 {
@@ -68,8 +69,9 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
         {
             _model.Setup(x => x.GetRelationById(RelationId)).Returns(_relation.Object);
 
-            object[] args = { _model.Object, _data };
-            RelationChangeTypeAction action = new RelationChangeTypeAction(args);
+            object[] args = { _model.Object, null, _data };
+            RelationChangeTypeAction action =
+                    Activator.CreateInstance(typeof(RelationChangeTypeAction), args) as RelationChangeTypeAction;
 
             Assert.AreEqual(3, action.Data.Count);
             Assert.AreEqual(RelationId.ToString(), _data["relation"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationChangeWeightActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationChangeWeightActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using DsmSuite.DsmViewer.Application.Actions.Relation;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
 {
@@ -68,8 +69,9 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
         {
             _model.Setup(x => x.GetRelationById(RelationId)).Returns(_relation.Object);
 
-            object[] args = { _model.Object, _data };
-            RelationChangeWeightAction action = new RelationChangeWeightAction(args);
+            object[] args = { _model.Object, null, _data };
+            RelationChangeWeightAction action =
+                    Activator.CreateInstance(typeof(RelationChangeWeightAction), args) as RelationChangeWeightAction;
 
             Assert.AreEqual(3, action.Data.Count);
             Assert.AreEqual(RelationId.ToString(), _data["relation"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationCreateActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationCreateActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Application.Actions.Relation;
 using Moq;
 using DsmSuite.DsmViewer.Model.Interfaces;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
 {
@@ -63,8 +64,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
         {
             _model.Setup(x => x.GetRelationById(RelationId)).Returns(_relation.Object);
 
-            object[] args = { _model.Object, _data };
-            RelationCreateAction action = new RelationCreateAction(args);
+            object[] args = { _model.Object, null, _data };
+            RelationCreateAction action = Activator.CreateInstance(typeof(RelationCreateAction), args) as RelationCreateAction;
             action.Undo();
 
             _model.Verify(x => x.RemoveRelation(RelationId), Times.Once());
@@ -75,8 +76,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
         {
             _model.Setup(x => x.GetRelationById(RelationId)).Returns(_relation.Object);
 
-            object[] args = { _model.Object, _data };
-            RelationCreateAction action = new RelationCreateAction(args);
+            object[] args = { _model.Object, null, _data };
+            RelationCreateAction action = Activator.CreateInstance(typeof(RelationCreateAction), args) as RelationCreateAction;
 
             Assert.AreEqual(5, action.Data.Count);
             Assert.AreEqual(RelationId.ToString(), _data["relation"]);

--- a/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationDeleteActionTest.cs
+++ b/DsmSuite.DsmViewer.Application.Test/Actions/Relation/RelationDeleteActionTest.cs
@@ -3,6 +3,7 @@ using DsmSuite.DsmViewer.Model.Interfaces;
 using Moq;
 using DsmSuite.DsmViewer.Application.Actions.Relation;
 using System.Collections.Generic;
+using System;
 
 namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
 {
@@ -63,8 +64,8 @@ namespace DsmSuite.DsmViewer.Application.Test.Actions.Relation
         {
             _model.Setup(x => x.GetDeletedRelationById(RelationId)).Returns(_relation.Object);
 
-            object[] args = { _model.Object, _data };
-            RelationDeleteAction action = new RelationDeleteAction(args);
+            object[] args = { _model.Object, null, _data };
+            RelationDeleteAction action = Activator.CreateInstance(typeof(RelationDeleteAction), args) as RelationDeleteAction;
 
             Assert.AreEqual(1, action.Data.Count);
             Assert.AreEqual(RelationId.ToString(), _data["relation"]);

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeNameAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeNameAction.cs
@@ -16,24 +16,20 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementChangeName;
 
-        public ElementChangeNameAction(object[] args)
+        public ElementChangeNameAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                    _old = attributes.GetString(nameof(_old));
-                    _new = attributes.GetString(nameof(_new));
-                }
+                _element = attributes.GetElement(nameof(_element));
+                _old = attributes.GetString(nameof(_old));
+                _new = attributes.GetString(nameof(_new));
             }
         }
+
 
         public ElementChangeNameAction(IDsmModel model, IDsmElement element, string name)
         {

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeParentAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeParentAction.cs
@@ -20,26 +20,21 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementChangeParent;
 
-        public ElementChangeParentAction(object[] args)
+        public ElementChangeParentAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                    _oldParent = attributes.GetElement(nameof(_oldParent));
-                    _oldIndex = attributes.GetInt(nameof(_oldIndex));
-                    _oldName = attributes.GetString(nameof(_oldName));
-                    _newParent = attributes.GetElement(nameof(_newParent));
-                    _newIndex = attributes.GetInt(nameof(_newIndex));
-                    _newName = attributes.GetString(nameof(_newName));
-                }
+                _element = attributes.GetElement(nameof(_element));
+                _oldParent = attributes.GetElement(nameof(_oldParent));
+                _oldIndex = attributes.GetInt(nameof(_oldIndex));
+                _oldName = attributes.GetString(nameof(_oldName));
+                _newParent = attributes.GetElement(nameof(_newParent));
+                _newIndex = attributes.GetInt(nameof(_newIndex));
+                _newName = attributes.GetString(nameof(_newName));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeTypeAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementChangeTypeAction.cs
@@ -16,24 +16,19 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementChangeType;
 
-        public ElementChangeTypeAction(object[] args)
+        public ElementChangeTypeAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                    _old = attributes.GetString(nameof(_old));
-                    _new = attributes.GetString(nameof(_new));
-                }
+                _element = attributes.GetElement(nameof(_element));
+                _old = attributes.GetString(nameof(_old));
+                _new = attributes.GetString(nameof(_new));
             }
-        }
+    }
 
         public ElementChangeTypeAction(IDsmModel model, IDsmElement element, string type)
         {

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementCreateAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementCreateAction.cs
@@ -19,29 +19,24 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementCreate;
 
-        public ElementCreateAction(object[] args)
+        public ElementCreateAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
+                _element = attributes.GetElement(nameof(_element));
+                _name = attributes.GetString(nameof(_name));
+                _type = attributes.GetString(nameof(_type));
+
+                int? parentId = attributes.GetNullableInt(nameof(_parent));
+                if (parentId.HasValue)
                 {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                    _name = attributes.GetString(nameof(_name));
-                    _type = attributes.GetString(nameof(_type));
-
-                    int? parentId = attributes.GetNullableInt(nameof(_parent));
-                    if (parentId.HasValue)
-                    {
-                        _parent = _model.GetElementById(parentId.Value);
-                    }
-                    _index = attributes.GetInt(nameof(_index));
+                    _parent = _model.GetElementById(parentId.Value);
                 }
+                _index = attributes.GetInt(nameof(_index));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementDeleteAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementDeleteAction.cs
@@ -14,20 +14,15 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementDelete;
 
-        public ElementDeleteAction(object[] args)
+        public ElementDeleteAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                }
+                 _element = attributes.GetElement(nameof(_element));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementMoveDownAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementMoveDownAction.cs
@@ -14,21 +14,12 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementMoveDown;
 
-        public ElementMoveDownAction(object[] args)
+        public ElementMoveDownAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
-            {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
-
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                }
-            }
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
+                _element = new ActionReadOnlyAttributes(_model, data).GetElement(nameof(_element));
         }
 
         public ElementMoveDownAction(IDsmModel model, IDsmElement element)

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementMoveUpAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementMoveUpAction.cs
@@ -14,20 +14,12 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementMoveUp;
 
-        public ElementMoveUpAction(object[] args)
+        public ElementMoveUpAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string,string> data)
         {
-            if (args.Length == 3)
-            {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                }
-            }
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
+                _element = new ActionReadOnlyAttributes(_model, data).GetElement(nameof(_element));
         }
 
         public ElementMoveUpAction(IDsmModel model, IDsmElement element)

--- a/DsmSuite.DsmViewer.Application/Actions/Element/ElementSortAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Element/ElementSortAction.cs
@@ -17,22 +17,17 @@ namespace DsmSuite.DsmViewer.Application.Actions.Element
 
         public const ActionType RegisteredType = ActionType.ElementSort;
 
-        public ElementSortAction(object[] args)
+        public ElementSortAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _element = attributes.GetElement(nameof(_element));
-                    _algorithm = attributes.GetString(nameof(_algorithm));
-                    _order = attributes.GetString(nameof(_order));
-                }
+                _element = attributes.GetElement(nameof(_element));
+                _algorithm = attributes.GetString(nameof(_algorithm));
+                _order = attributes.GetString(nameof(_order));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Relation/RelationChangeTypeAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Relation/RelationChangeTypeAction.cs
@@ -18,24 +18,19 @@ namespace DsmSuite.DsmViewer.Application.Actions.Relation
 
         public const ActionType RegisteredType = ActionType.RelationChangeType;
 
-        public RelationChangeTypeAction(object[] args)
+        public RelationChangeTypeAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _relation = attributes.GetRelation(nameof(_relation));
-                    _consumer = attributes.GetRelationConsumer(nameof(_relation));
-                    _provider = attributes.GetRelationProvider(nameof(_relation));
-                    _old = attributes.GetString(nameof(_old));
-                    _new = attributes.GetString(nameof(_new));
-                }
+                _relation = attributes.GetRelation(nameof(_relation));
+                _consumer = attributes.GetRelationConsumer(nameof(_relation));
+                _provider = attributes.GetRelationProvider(nameof(_relation));
+                _old = attributes.GetString(nameof(_old));
+                _new = attributes.GetString(nameof(_new));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Relation/RelationChangeWeightAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Relation/RelationChangeWeightAction.cs
@@ -18,24 +18,19 @@ namespace DsmSuite.DsmViewer.Application.Actions.Relation
 
         public const ActionType RegisteredType = ActionType.RelationChangeWeight;
 
-        public RelationChangeWeightAction(object[] args)
+        public RelationChangeWeightAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _relation = attributes.GetRelation(nameof(_relation));
-                    _consumer = attributes.GetRelationConsumer(nameof(_relation));
-                    _provider = attributes.GetRelationProvider(nameof(_relation));
-                    _old = attributes.GetInt(nameof(_old));
-                    _new = attributes.GetInt(nameof(_new));
-                }
+                _relation = attributes.GetRelation(nameof(_relation));
+                _consumer = attributes.GetRelationConsumer(nameof(_relation));
+                _provider = attributes.GetRelationProvider(nameof(_relation));
+                _old = attributes.GetInt(nameof(_old));
+                _new = attributes.GetInt(nameof(_new));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Relation/RelationCreateAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Relation/RelationCreateAction.cs
@@ -18,24 +18,19 @@ namespace DsmSuite.DsmViewer.Application.Actions.Relation
 
         public const ActionType RegisteredType = ActionType.RelationCreate;
 
-        public RelationCreateAction(object[] args)
+        public RelationCreateAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _relation = attributes.GetRelation(nameof(_relation));
-                    _consumer = attributes.GetRelationConsumer(nameof(_relation));
-                    _provider = attributes.GetRelationProvider(nameof(_relation));
-                    _type = attributes.GetString(nameof(_type));
-                    _weight = attributes.GetInt(nameof(_weight));
-                }
+                _relation = attributes.GetRelation(nameof(_relation));
+                _consumer = attributes.GetRelationConsumer(nameof(_relation));
+                _provider = attributes.GetRelationProvider(nameof(_relation));
+                _type = attributes.GetString(nameof(_type));
+                _weight = attributes.GetInt(nameof(_weight));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Actions/Relation/RelationDeleteAction.cs
+++ b/DsmSuite.DsmViewer.Application/Actions/Relation/RelationDeleteAction.cs
@@ -16,22 +16,17 @@ namespace DsmSuite.DsmViewer.Application.Actions.Relation
 
         public const ActionType RegisteredType = ActionType.RelationDelete;
 
-        public RelationDeleteAction(object[] args)
+        public RelationDeleteAction(IDsmModel model, IActionContext context, IReadOnlyDictionary<string, string> data)
         {
-            if (args.Length == 3)
+            _model = model;
+            _actionContext = context;
+            if (_model != null  &&  data != null)
             {
-                _model = args[0] as IDsmModel;
-                _actionContext = args[1] as IActionContext;
-                IReadOnlyDictionary<string, string> data = args[2] as IReadOnlyDictionary<string, string>;
+                ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
 
-                if ((_model != null) && (data != null))
-                {
-                    ActionReadOnlyAttributes attributes = new ActionReadOnlyAttributes(_model, data);
-
-                    _relation = attributes.GetRelation(nameof(_relation));
-                    _consumer = attributes.GetRelationConsumer(nameof(_relation));
-                    _provider = attributes.GetRelationProvider(nameof(_relation));
-                }
+                _relation = attributes.GetRelation(nameof(_relation));
+                _consumer = attributes.GetRelationConsumer(nameof(_relation));
+                _provider = attributes.GetRelationProvider(nameof(_relation));
             }
         }
 

--- a/DsmSuite.DsmViewer.Application/Interfaces/IAction.cs
+++ b/DsmSuite.DsmViewer.Application/Interfaces/IAction.cs
@@ -2,17 +2,61 @@
 
 namespace DsmSuite.DsmViewer.Application.Interfaces
 {
+    /// <summary>
+    /// An action the user can perform in the application.<para/>
+    /// Actions execute on the data in the <see cref="Data"/> property. This data is injected
+    /// into the constructor.<br/>
+    /// When the model is saved, the <see cref="Data"/> property is saved with the action.<br/>
+    /// When loading the model again, the action is re-created using a
+    /// <c>constructor(IDsmModel m, IActionContext c, IReadOnlyDictionary&lt;string,string&gt; data)</c>.
+    /// </summary>
     public interface IAction
     {
+        /// <summary>
+        /// The unique type for this action.
+        /// </summary>
+        /// todo only used by ActionStore for impex. Implement locally there and remove here.
         ActionType Type { get; }
+
+        /// <summary>
+        /// String that identifies this action in menus and action lists (e.g. undo/redo).<para/>
+        /// This must be the same for all instances of the action.
+        /// </summary>
         string Title { get; }
+
+        /// <summary>
+        /// String that describes the details of this particular action for informative purposes
+        /// (e.g. in undo/redo).<para/>
+        /// This usually returns a different text for different instances of the action, based
+        /// on the contents of <see cref="Data"/>.
+        /// </summary>
         string Description { get; }
 
+        /// <summary>
+        /// Perform this action using the data stored in <c>Data</c>.<br/>
+        /// This usually returns null, except for actions that are expected by the application to
+        /// return some useful object, like create actions.
+        /// </summary>
+        /// <returns>Some relevant object or null</returns>
         object Do();
+
+        /// <summary>
+        /// Undo the result of <c>Do()</c>.
+        /// </summary>
         void Undo();
 
+        /// <summary>
+        /// Return true iff this action has all the data it needs to be done/undone.
+        /// </summary>
         bool IsValid();
 
+        /// <summary>
+        /// A key->value map of the data this action needs to be performed, injected into the
+        /// constructor.<para/>
+        /// The implementing class can determine the contents and format of Data itself, but
+        /// <c>ActionAttributes</c> and <c>ActionReadOnlyAttributes</c> provide convenience
+        /// functions for this.
+        /// </summary>
         IReadOnlyDictionary<string, string> Data { get; }
     }
 }

--- a/DsmSuite.DsmViewer.Model.Test/Core/DsmElementTest.cs
+++ b/DsmSuite.DsmViewer.Model.Test/Core/DsmElementTest.cs
@@ -195,19 +195,74 @@ namespace DsmSuite.DsmViewer.Model.Test.Core
         [TestMethod]
         public void TestContainChildWithName()
         {
-            Assert.Inconclusive("To be implemented");
+            string childName = "the name";
+
+            int parentId = 1;
+            string parentName = "parent";
+            DsmElement parent = new DsmElement(parentId, parentName, "", null);
+            Assert.IsFalse(parent.ContainsChildWithName(childName));
+
+            DsmElement child1 = new DsmElement(10, "Child 1", "", null);
+            parent.InsertChildAtEnd(child1);
+            Assert.IsFalse(parent.ContainsChildWithName(childName));
+
+            DsmElement child2 = new DsmElement(11, "Child 2", "", null);
+            parent.InsertChildAtEnd(child2);
+            Assert.IsFalse(parent.ContainsChildWithName(childName));
+
+            DsmElement theChild = new DsmElement(2, childName, "", null);
+            parent.InsertChildAtEnd(theChild);
+            Assert.IsTrue(parent.ContainsChildWithName(childName));
+            Assert.IsFalse(parent.ContainsChildWithName(childName.ToUpper()));
+            Assert.IsFalse(parent.ContainsChildWithName("the náme"));
         }
 
         [TestMethod]
         public void TestInsertElementIndexInRange()
         {
-            Assert.Inconclusive("To be implemented");
+            int parentId = 1;
+            string parentName = "parent";
+            DsmElement parent = new DsmElement(parentId, parentName, "", null);
+            Assert.AreEqual(0, parent.Children.Count);
+
+            DsmElement child1 = new DsmElement(10, "child 1", "", null);
+            parent.InsertChildAtIndex(child1, 0);
+            Assert.AreEqual(1, parent.Children.Count);
+            Assert.AreEqual(parent, child1.Parent);
+
+            DsmElement child2 = new DsmElement(11, "child 2", "", null);
+            parent.InsertChildAtIndex(child2, 0);
+            Assert.AreEqual(2, parent.Children.Count);
+            Assert.AreEqual(parent, child2.Parent);
+
+            DsmElement child3 = new DsmElement(12, "child 3", "", null);
+            parent.InsertChildAtIndex(child3, 2);
+            Assert.AreEqual(3, parent.Children.Count);
+            Assert.AreEqual(parent, child3.Parent);
         }
 
         [TestMethod]
         public void TestInsertElementOutOfRange()
         {
-            Assert.Inconclusive("To be implemented");
+            int parentId = 1;
+            string parentName = "parent";
+            DsmElement parent = new DsmElement(parentId, parentName, "", null);
+            Assert.AreEqual(0, parent.Children.Count);
+
+            DsmElement child1 = new DsmElement(10, "child 1", "", null);
+            parent.InsertChildAtIndex(child1, 1);
+            Assert.AreEqual(1, parent.Children.Count);
+            Assert.AreEqual(parent, child1.Parent);
+
+            DsmElement child2 = new DsmElement(11, "child 2", "", null);
+            parent.InsertChildAtIndex(child2, 1000*1000);
+            Assert.AreEqual(2, parent.Children.Count);
+            Assert.AreEqual(parent, child2.Parent);
+
+            DsmElement child3 = new DsmElement(12, "child 3", "", null);
+            parent.InsertChildAtIndex(child3, -1);
+            Assert.AreEqual(3, parent.Children.Count);
+            Assert.AreEqual(parent, child3.Parent);
         }
     }
 }


### PR DESCRIPTION
Resolves #30. Makes all tests runnable, fixes some issues revealed by the tests and adds/implements some new tests.

Analyzer tests and fixes:
    Fix bugs regarding one/multiple AssemblyDirectories.
    Add tests for the analyzer.
    Document Inputsettings.

Implemented missing model tests.

DsmViewer:
    IAction constructors and tests
    Add IActionContext parameter to Iaction implementing constructors.
    Use argument list instead of object[] for IAction constructor arguments.
    Implement not yet implemented IAction tests.
    Tests construct IActions using Activator.CreateInstance instead of new where the viewer does so.
    Implemented missing model tests.